### PR TITLE
Include homeDir in default sass path resolution

### DIFF
--- a/src/stylesheet/sassHandler.ts
+++ b/src/stylesheet/sassHandler.ts
@@ -81,7 +81,7 @@ export async function renderModule(props: IRenderModuleProps): Promise<IStyleshe
     data: module.contents,
     file: module.props.absPath,
     sourceMap: requireSourceMap,
-    includePaths: [path.dirname(module.props.absPath)],
+    includePaths: [path.dirname(module.props.absPath), ctx.config.homeDir],
     outFile: module.props.absPath,
     sourceMapContents: requireSourceMap,
     importer: function(url, prev) {


### PR DESCRIPTION
in a directory structure like
```
packages/
    app/ 
        main.scss 
    core/
        styles/
            colours.scss
```
 I want to be able to `@import core/styles/colours.scss` from `app/main.scss`